### PR TITLE
fix(cmake): Replace deprecated FetchContent_Populate with FetchContent_MakeAvailable

### DIFF
--- a/source/lmp/plugin/CMakeLists.txt
+++ b/source/lmp/plugin/CMakeLists.txt
@@ -8,11 +8,8 @@ if(DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
       lammps_download
       GIT_REPOSITORY https://github.com/lammps/lammps
       GIT_TAG ${LAMMPS_VERSION})
-    FetchContent_GetProperties(lammps_download)
-    if(NOT lammps_download_POPULATED)
-      FetchContent_Populate(lammps_download)
-      set(LAMMPS_SOURCE_ROOT ${lammps_download_SOURCE_DIR})
-    endif()
+    FetchContent_MakeAvailable(lammps_download)
+    set(LAMMPS_SOURCE_ROOT ${lammps_download_SOURCE_DIR})
   endif()
   set(LAMMPS_HEADER_DIR ${LAMMPS_SOURCE_ROOT}/src)
   message(STATUS "LAMMPS_HEADER_DIR is ${LAMMPS_HEADER_DIR}")
@@ -77,7 +74,7 @@ if(DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
     target_precompile_headers(${libname} PUBLIC [["deepmd.hpp"]])
     remove_definitions(-D_GLIBCXX_USE_CXX11_ABI=${OP_CXX_ABI})
     if("$ENV{CIBUILDWHEEL}" STREQUAL "1" OR "$ENV{LMP_CXX11_ABI_0}" STREQUAL
-                                            "1")
+                                           "1")
       add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
     endif()
   else()
@@ -96,7 +93,7 @@ if(DEFINED LAMMPS_SOURCE_ROOT OR DEFINED LAMMPS_VERSION)
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set_target_properties(${libname} PROPERTIES LINK_FLAGS
-                                                "-Wl,-undefined,dynamic_lookup")
+                                               "-Wl,-undefined,dynamic_lookup")
   else()
     set_target_properties(
       ${libname} PROPERTIES INSTALL_RPATH "$ORIGIN;${BACKEND_LIBRARY_PATH}"


### PR DESCRIPTION
Update `source/lmp/plugin/CMakeLists.txt` to use `FetchContent_MakeAvailable` instead of `FetchContent_Populate`.

* Replace `FetchContent_Populate(lammps_download)` with `FetchContent_MakeAvailable(lammps_download)` on line 13.
* Remove `FetchContent_GetProperties` and `if(NOT lammps_download_POPULATED)` block.

This fixes a CMake warning:
```
CMake Warning (dev) at /home/runner/work/_temp/-111029589/cmake-3.30.5-linux-x86_64/share/cmake-3.30/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(lammps_download) is deprecated, call
  FetchContent_MakeAvailable(lammps_download) instead.  Policy CMP0169 can be
  set to OLD to allow FetchContent_Populate(lammps_download) to be called
  directly for now, but the ability to call it with declared details will be
  removed completely in a future version.
Call Stack (most recent call first):
  lmp/plugin/CMakeLists.txt:13 (FetchContent_Populate)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/njzjz/deepmd-kit?shareId=0008b589-a56a-4816-8f22-55d3a6a3c1f3).