### PR TITLE
Fix UT `test_tf_consistent_with_ref`

### DIFF
--- a/deepmd/tf/fit/polar.py
+++ b/deepmd/tf/fit/polar.py
@@ -638,7 +638,6 @@ class PolarFittingSeA(Fitting):
                 "fparam_inv_std": None,
                 "aparam_avg": None,
                 "aparam_inv_std": None,
-                "case_embd": None,
                 "scale": self.scale.reshape(-1, 1),
                 "constant_matrix": self.constant_matrix.reshape(-1),
             },

--- a/source/tests/consistent/common.py
+++ b/source/tests/consistent/common.py
@@ -328,6 +328,7 @@ class CommonTest(ABC):
 
         if tf_obj.__class__.__name__.startswith("Polar"):
             data1["@variables"].pop("bias_atom_e")
+            data2["@variables"].pop("case_embd")
 
         np.testing.assert_equal(data1, data2)
         for rr1, rr2 in zip(ret1, ret2):

--- a/source/tests/consistent/common.py
+++ b/source/tests/consistent/common.py
@@ -328,7 +328,6 @@ class CommonTest(ABC):
 
         if tf_obj.__class__.__name__.startswith("Polar"):
             data1["@variables"].pop("bias_atom_e")
-            data2["@variables"].pop("case_embd")
 
         np.testing.assert_equal(data1, data2)
         for rr1, rr2 in zip(ret1, ret2):


### PR DESCRIPTION
This PR pop variable `case_embd` to pass the UT for polarizability in r3.0.2. This operation is temporary and should be overrided in r3.1.